### PR TITLE
terraform: link gke cluster to the subnetwork and improve outputs

### DIFF
--- a/terraform/gcp/template/kubernetes_engine.tf
+++ b/terraform/gcp/template/kubernetes_engine.tf
@@ -13,7 +13,7 @@ resource "google_container_cluster" "vectice" {
   ip_allocation_policy {}
 
   network = "projects/${var.project_id}/global/networks/${var.network}"
-  subnetwork = "projects/${var.project_id}/regions/${var.region}/subnetworks/${var.subnetwork}"
+  subnetwork = google_compute_subnetwork.subnet1.id
 
   enable_shielded_nodes = true
 

--- a/terraform/gcp/template/outputs.tf
+++ b/terraform/gcp/template/outputs.tf
@@ -1,22 +1,4 @@
-output "SQL_instance_internal_IP_address" {
-  value = google_sql_database_instance.vectice.private_ip_address
-  description = "global.database.host"
-}
 
-output "SQL_instance_internal_IP_address" {
-  value = var.db_username
-  description = "global.database.username"
-}
-
-output "SQL_instance_internal_IP_address" {
-  value = var.db_password
-  description = "global.database.password"
-}
-
-output "SQL_instance_service_account" {
-  value = google_sql_database_instance.vectice.service_account_email_address
-  description = "service_account_sql_instance"
-}
 output "Bucket_name" {
   value = google_storage_bucket.vectice_project.name
   description = "Bucket name"
@@ -30,8 +12,20 @@ output "SQL_cert_name" {
   value = var.client_cert_name
   description = "SQL_instance_cert_name"
 }
+output "SQL_instance_external_IP_address" {
+  value = google_sql_database_instance.vectice.ip_address.0.ip_address
+  description = "SQL_instance_external_IP_addres"
+}
 
+output "SQL_instance_internal_IP_address" {
+  value = google_sql_database_instance.vectice.private_ip_address
+  description = "SQL_instance_internal_IP_address"
+}
 
+output "SQL_instance_service_account" {
+  value = google_sql_database_instance.vectice.service_account_email_address
+  description = "service_account_sql_instance"
+}
 output "SQL_instance_region" {
   value = google_sql_database_instance.vectice.region
   description = "SQL instance region"

--- a/terraform/gcp/template/vpc.tf
+++ b/terraform/gcp/template/vpc.tf
@@ -19,16 +19,8 @@ resource "google_service_networking_connection" "vectice" {
 
 # Define subnet 1
 resource "google_compute_subnetwork" "subnet1" {
-  name          = "${var.subnetwork}1"
+  name          = "${var.subnetwork}"
   ip_cidr_range = var.cidr_range_subnet1
-  region        = var.region # Change this to your desired region
-  network       = google_compute_network.vectice_vpc.self_link
-}
-
-# Define subnet 2
-resource "google_compute_subnetwork" "subnet2" {
-  name          = "${var.subnetwork}2"
-  ip_cidr_range = var.cidr_range_subnet2
   region        = var.region # Change this to your desired region
   network       = google_compute_network.vectice_vpc.self_link
 }


### PR DESCRIPTION
## Type of Change

- [ ] **CI**: Content in the CI/CD workflows
- [ ] **Helm**: Templates or values to deploy Vectice full stack 
- [x] **Terraform**: Creations of Infrastructure on GCP
- [ ] **Documentation**: Update on User Guide or documentation in helm templates

## Description

terraform: link gke cluster to the subnetwork and improve outputs

